### PR TITLE
PRI-1385 [DM] Add support for Ubuntu 16.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,9 @@ driver:
 provisioner:
   name: ansible_playbook
   hosts: test-kitchen
+  require_pip: true
+  require_ansible_repo: false
+  ansible_version:  2.5.6.0
   ansible_verbose: false
   ansible_verbosity: 2
   ansible_diff: true
@@ -14,6 +17,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
 
 suites:
   - name: passwd-watch

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -2,4 +2,4 @@
 - name: Install packages
   apt:
     name: auditd
-    state: installed
+    state: present

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -2,4 +2,4 @@
 - name: Install packages
   yum:
     name: audit
-    state: installed
+    state: present


### PR DESCRIPTION
- support for ubuntu 16.04 added
- fixed Ansible deprecated warnings for state parameter.
- successfully tested changes locally

```
$ kitchen verify passwd-watch-ubuntu-1604
-----> Starting Kitchen (v1.16.0)
-----> Setting up <passwd-watch-ubuntu-1604>...
       Finished setting up <passwd-watch-ubuntu-1604> (0m0.00s).
-----> Verifying <passwd-watch-ubuntu-1604>...
       Preparing files for transfer
-----> Installing Busser (busser)
Fetching: thor-0.19.0.gem (100%)
       Successfully installed thor-0.19.0
Fetching: busser-0.7.1.gem (100%)
       Successfully installed busser-0.7.1
       2 gems installed
       Installing Busser plugins: busser-serverspec
       Plugin serverspec installed (version 0.5.10)
-----> Running postinstall for serverspec plugin
       Suite path directory /tmp/verifier/suites does not exist, skipping.
       Transferring files to <passwd-watch-ubuntu-1604>
-----> Running serverspec test suite
-----> Installing Serverspec..
Fetching: diff-lcs-1.3.gem (100%)
Fetching: rspec-expectations-3.7.0.gem (100%)
Fetching: rspec-mocks-3.7.0.gem (100%)
Fetching: rspec-3.7.0.gem (100%)
Fetching: rspec-its-1.2.0.gem (100%)
Fetching: multi_json-1.13.1.gem (100%)
Fetching: net-ssh-5.0.2.gem (100%)
Fetching: net-scp-1.2.1.gem (100%)
Fetching: net-telnet-0.2.0.gem (100%)
Fetching: sfl-2.3.gem (100%)
Fetching: specinfra-2.75.0.gem (100%)
Fetching: serverspec-2.41.3.gem (100%)
-----> serverspec installed (version 2.41.3)
       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.7.1/lib:/tmp/verifier/gems/gems/rspec-core-3.7.1/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec
       
       File "/etc/audit"
         should be directory
       
       File "/etc/audit/auditd.conf"
         should be file
       
       File "/etc/audit/audit.rules"
         should be file
       
       Package "auditd"
         should be installed
       
       Service "auditd"
         should be enabled
         should be running
       
       File "/etc/audit/audit.rules"
         content
           should match /passwd_changes/
       
       File "/var/log/audit/audit.log"
         content
           should match /\/etc\/passwd.*nametype=CREATE/
       
       Finished in 0.10908 seconds (files took 0.30225 seconds to load)
       8 examples, 0 failures
       
       Finished verifying <passwd-watch-ubuntu-1604> (0m11.72s).
-----> Kitchen is finished. (0m11.89s)
```